### PR TITLE
add poison to whitelist

### DIFF
--- a/phase_4/etc/twhitelist.dat
+++ b/phase_4/etc/twhitelist.dat
@@ -31659,6 +31659,7 @@ pointing
 points
 poisend
 poish
+poison
 pokemon
 pokercheat
 pokereval


### PR DESCRIPTION
guy in-game is named poison. if it's an allowed name, why not an allowed word?
