### PR TITLE
Updated Whitelist

### DIFF
--- a/phase_4/etc/twhitelist.dat
+++ b/phase_4/etc/twhitelist.dat
@@ -1232,6 +1232,7 @@ amend
 amending
 amends
 amenities
+america
 american
 amethyst
 amidships
@@ -2725,7 +2726,6 @@ bananapocket
 Bananapocket
 bananapoof
 Bananapoof
-bananapop
 bananapop
 Bananapop
 bananapounce
@@ -6560,6 +6560,7 @@ c.f.o.s
 c'mon
 c(:
 c++
+c#
 ca'me
 cab
 caballeros
@@ -7051,8 +7052,10 @@ catacomb
 catacombs
 catalog
 catalog's
+cataloging
 catalogs
 catalogue
+cataloguing
 catalyst
 catapult
 cataract
@@ -10493,6 +10496,8 @@ crypts
 crystal
 crystal's
 crystals
+cs
+cscript
 ctf
 ctrl
 cub
@@ -14473,6 +14478,9 @@ empoison
 emporium
 emporium's
 emporiums
+empower
+empowered
+empowering
 empress
 empresses
 emptied
@@ -16071,6 +16079,7 @@ fiery
 fifi
 fifi's
 fifth
+fig
 figaro
 figaro's
 figaros
@@ -17595,6 +17604,7 @@ fridge
 fried
 friend
 friend's
+friended
 friendlier
 friendly
 friends
@@ -21418,6 +21428,7 @@ herons
 heros
 herring
 herrings
+herro
 hers
 herself
 hershey
@@ -22593,6 +22604,9 @@ implications
 implicit
 implied
 implies
+implode
+imploded
+imploding
 imploringly
 imply
 implying
@@ -23631,6 +23645,8 @@ jasmines
 jason
 jason's
 jasons
+java
+javascript
 jaw
 jaw-dropper
 jaw's
@@ -24194,6 +24210,7 @@ jpn
 jps
 jr
 jr.
+js
 juan
 jubilee
 judge
@@ -24445,6 +24462,7 @@ kenai
 kenai's
 kenais
 kennel
+kenneth
 kenny
 kenny's
 kennys
@@ -25121,6 +25139,7 @@ legends
 leghorn
 legion
 legit
+lego
 legondary
 legs
 leibovitz
@@ -27263,6 +27282,7 @@ micromanagers
 microphone
 microphone's
 microphones
+microsoft
 middle
 middled
 middler
@@ -27765,6 +27785,7 @@ monkies
 monks
 monocle
 monocles
+monodevelop
 monopolize
 monopolized
 monopolizes
@@ -28562,6 +28583,7 @@ note
 notebook
 noted
 notepad
+notepad++
 notepads
 noter
 notes
@@ -28850,6 +28872,7 @@ objective
 objects
 obnoxious
 obnoxiously
+obs
 obscure
 obsequious
 observation
@@ -29292,12 +29315,14 @@ or
 oracle
 orange
 oranges
+orb
 orbit
 orbited
 orbiter
 orbiters
 orbiting
 orbits
+orbs
 orcas
 orchana
 orchard
@@ -35401,6 +35426,8 @@ sailorly
 sailors
 sails
 sailsmen
+saint
+saints
 saj
 sake
 sal
@@ -36223,6 +36250,7 @@ shuffling
 shulla
 shut
 shut-eye
+shutdown
 shuts
 shuttle
 shy
@@ -38116,6 +38144,7 @@ spider
 spider-silk
 spider-toon
 spider's
+spiderman
 spiders
 spidertoon
 spidertoons
@@ -39062,13 +39091,13 @@ Superhoffer
 superhopper
 Superhopper
 superior
-superior
 superjinks
 Superjinks
 superklunk
 Superklunk
 superknees
 Superknees
+superman
 supermarble
 Supermarble
 supermash
@@ -39889,6 +39918,7 @@ thrills
 thrillseeker
 thrives
 throne
+thrones
 through
 throughly
 throughout
@@ -40956,6 +40986,7 @@ trier
 triers
 tries
 trifle
+triforce
 triggerfish
 trike
 trillion
@@ -42114,6 +42145,8 @@ velociraptor
 velvet
 velvet-moss
 veni
+venom
+venomous
 venture
 ventures
 venue
@@ -42217,6 +42250,9 @@ visiting
 visitors
 visits
 vista
+visual
+visualization
+visualize
 vitae
 vitality
 vittles
@@ -44735,6 +44771,7 @@ yolo
 yom
 yoo
 york
+yoshi
 you
 you'd
 you'll
@@ -44797,6 +44834,7 @@ zebra's
 zebras
 zeddars
 zeke
+zelda
 zen
 zenon
 zephyr


### PR DESCRIPTION
Added 
"america" "c#" "cataloging" "cataloguing" "cs" "cscript" "empower" "empowered" "empowering" "fig" "friended" "herro" "implode" "imploded" "imploding" "java" "javascript" "js" "kenneth" "lego" "microsoft" "monodevelop" "notepad++" "obs" "orb" "orbs" "saint" "saints" "shutdown" "spiderman" "superman" "thrones" "triforce" "venom" "venomous" "visual" "visualization" "visualize" "yoshi" "zelda"

Removed Extra 
"bananapop" "superior" 

Is This Acceptable?
